### PR TITLE
dereference arrayref of conditions to iterate

### DIFF
--- a/JMAP/API.pm
+++ b/JMAP/API.pm
@@ -560,13 +560,13 @@ sub _match_operator {
     return not $Self->_match_operator($item, {operator => 'OR', conditions => $filter->{conditions}}, $storage);
   }
   elsif ($filter->{operator} eq 'OR') {
-    foreach my $condition ($filter->{conditions}) {
+    foreach my $condition (@{ $filter->{conditions} }) {
       return 1 if $Self->_match($item, $condition, $storage);
     }
     return 0;
   }
   elsif ($filter->{operator} eq 'AND') {
-    foreach my $condition ($filter->{conditions}) {
+    foreach my $condition (@{ $filter->{conditions} }) {
       return 0 if $Self->_match($item, $condition, $storage);
     }
     return 1;


### PR DESCRIPTION
AND/OR/NOT filter conditions don't work because they're missing a deref.  This adds it.
