### PR TITLE
import messages: not to-spec (outdated?) and broken

### DIFF
--- a/JMAP/API.pm
+++ b/JMAP/API.pm
@@ -1207,6 +1207,10 @@ sub importMessage {
   my $Self = shift;
   my $args = shift;
 
+  my ($type, $message) = $Self->{db}->get_file($args->{file});
+  return $Self->_transError(['error', {type => 'notFound'}])
+    if (not $type or $type ne 'message/rfc822');
+
   $Self->begin();
 
   my $user = $Self->{db}->get_user();
@@ -1218,10 +1222,6 @@ sub importMessage {
     if not $args->{file};
   return $Self->_transError(['error', {type => 'invalidArguments'}])
     if not $args->{mailboxIds};
-
-  my ($type, $message) = $Self->{db}->get_file($args->{file});
-  return $Self->_transError(['error', {type => 'notFound'}])
-    if (not $type or $type ne 'message/rfc822');
 
   $Self->commit();
 

--- a/JMAP/API.pm
+++ b/JMAP/API.pm
@@ -1227,7 +1227,7 @@ sub importMessage {
 
   # import to a normal mailbox (or boxes)
   my @ids = map { $Self->idmap($_) } @{$args->{mailboxIds}};
-  my ($msgid, $thrid) = $Self->import_message($message, \@ids,
+  my ($msgid, $thrid) = $Self->{db}->import_message($message, \@ids,
     isUnread => $args->{isUnread},
     isFlagged => $args->{isFlagged},
     isAnswered => $args->{isAnswered},


### PR DESCRIPTION
This is more an issue than a PR, but I'm including some patches that _partly_ sort out problems.  Here are the problems:
1. jmap-proxy provides importMessage, not importMessages.  It looks like the spec changed in Jun 2015 and the implementation is lagging.
2. The implementation of importMessage begins a transaction, then calls get_file, which tries to begin again.  I have included a patch to get_file first, which may or may not be okay.  I don't know the code well enough to say.
3.  The implementation of importMessage calls import_message on JMAP::API, but it appears it should be called on `$Self->{db}`.  I have included a patch.

Even with these changes made, I end up getting an error from the IMAP end: APPEND failed.  I stopped digging there, because that's where I stopped knowing it was problems in jmap-proxy and started wondering whether it was back to being a problem in my client code.

Really:  proxy needs to implement importMessage**s**, anyway.
