### PR TITLE
use cmp for sorting strings

### DIFF
--- a/JMAP/ImapDB.pm
+++ b/JMAP/ImapDB.pm
@@ -1497,7 +1497,7 @@ sub create_mailboxes {
 
   $Self->commit();
 
-  foreach my $cid (sort { $todo{$a} <=> $todo{$b} } keys %todo) {
+  foreach my $cid (sort { $todo{$a} cmp $todo{$b} } keys %todo) {
     my $imapname = $todo{$cid};
     # XXX - check if already exists?
     my $res = $Self->backend_cmd('create_mailbox', $imapname);


### PR DESCRIPTION
The values in %todo are folder names to be used in the
IMAP create commands.  We should compare them with cmp,
since they are strings.
