### PR TITLE
Update Makefile - Debian packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,19 @@ PACKAGES=                   \
   libdbi-perl               \
   libemail-address-perl     \
   libemail-mime-perl        \
+  libencode-imaputf7-perl   \
+  libexpat1-dev             \
   libhtml-parser-perl       \
   libhtml-strip-perl        \
   libhttp-date-perl         \
   libhttp-tiny-perl         \
   libimage-size-perl        \
   libio-socket-ssl-perl     \
-  libencode-imaputf7-perl   \
   libjson-perl              \
   libjson-xs-perl           \
   liblocale-gettext-perl    \
   libswitch-perl            \
+  libtest-xml-perl          \
   nginx                     \
 
 PERLPACKAGES=                     \


### PR DESCRIPTION
Debian packages libexpat1-dev libtest-xml-perl added, which are needed for building Net::CardDAVTalk