### PR TITLE
Automatically release superlocks when we no longer need them

### DIFF
--- a/JMAP/API.pm
+++ b/JMAP/API.pm
@@ -909,7 +909,7 @@ sub api_Mailbox_set {
   my ($created, $notCreated, $updated, $notUpdated, $destroyed, $notDestroyed);
   my ($oldState, $newState);
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     # make sure our DB is up to date - happy to enforce this because folder names
@@ -934,11 +934,8 @@ sub api_Mailbox_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['Mailbox/set', {
@@ -1772,7 +1769,7 @@ sub api_Email_set {
   my ($created, $notCreated, $updated, $notUpdated, $destroyed, $notDestroyed);
   my ($oldState, $newState);
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     # get state up-to-date first
@@ -1799,11 +1796,8 @@ sub api_Email_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   foreach my $cid (sort keys %$created) {
     my $msgid = $created->{$cid}{id};
@@ -1833,7 +1827,7 @@ sub api_Email_import {
   my %created;
   my %notcreated;
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   # make sure our DB is up to date
   $Self->{db}->sync_folders();
@@ -1895,8 +1889,6 @@ sub api_Email_import {
       size => $size,
     };
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['Email/import', {
@@ -2751,7 +2743,7 @@ sub api_ContactGroup_set {
   my ($created, $notCreated, $updated, $notUpdated, $destroyed, $notDestroyed);
   my ($oldState, $newState);
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     $Self->{db}->sync_addressbooks();
@@ -2777,11 +2769,8 @@ sub api_ContactGroup_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['ContactGroup/set', {
@@ -2818,7 +2807,7 @@ sub api_Contact_set {
   my ($created, $notCreated, $updated, $notUpdated, $destroyed, $notDestroyed);
   my ($oldState, $newState);
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     $Self->{db}->sync_addressbooks();
@@ -2844,11 +2833,8 @@ sub api_Contact_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['Contact/set', {
@@ -2886,7 +2872,7 @@ sub api_CalendarEvent_set {
   my ($created, $notCreated, $updated, $notUpdated, $destroyed, $notDestroyed);
   my ($oldState, $newState);
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     $Self->{db}->sync_calendars();
@@ -2912,11 +2898,8 @@ sub api_CalendarEvent_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['CalendarEvent/set', {
@@ -2953,7 +2936,7 @@ sub api_Calendar_set {
   my ($created, $notCreated, $updated, $notUpdated, $destroyed, $notDestroyed);
   my ($oldState, $newState);
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     $Self->{db}->sync_calendars();
@@ -2979,11 +2962,8 @@ sub api_Calendar_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['Calendar/set', {
@@ -3314,7 +3294,7 @@ sub api_EmailSubmission_set {
   my %updateEmails;
   my @destroyEmails;
 
-  $Self->{db}->begin_superlock();
+  my $scoped_lock = $Self->{db}->begin_superlock();
 
   eval {
     # make sure our DB is up to date
@@ -3366,11 +3346,8 @@ sub api_EmailSubmission_set {
   };
 
   if ($@) {
-    $Self->{db}->end_superlock();
     die $@;
   }
-
-  $Self->{db}->end_superlock();
 
   my @res;
   push @res, ['EmailSubmission/set', {

--- a/JMAP/DB.pm
+++ b/JMAP/DB.pm
@@ -26,6 +26,7 @@ use Date::Parse;
 use Net::CalDAVTalk;
 use Net::CardDAVTalk::VCard;
 use MIME::Base64 qw(encode_base64 decode_base64);
+use Scalar::Util qw(weaken);
 
 my $json = JSON::XS->new->utf8->canonical();
 
@@ -94,12 +95,10 @@ sub in_transaction {
 sub begin_superlock {
   my $Self = shift;
   my $accountid = $Self->accountid();
-  $Self->{superlock} = IO::LockedFile->new(">/home/jmap/data/$accountid.lock");
-}
-
-sub end_superlock {
-  my $Self = shift;
-  delete $Self->{superlock};
+  my $lock = IO::LockedFile->new(">/home/jmap/data/$accountid.lock");
+  $Self->{superlock} = $lock;
+  weaken $Self->{superlock};
+  return $lock;
 }
 
 sub begin {


### PR DESCRIPTION
We do this by making $Self->{superlock} a weakref to the lock
and returning it to the upper scope in begin_superlock().

As long as the upper scope hangs onto the lock scalar, they
have the lock.

This way, we don't have to make sure to always call end_superlock()
(which we weren't doing in cases like invalidArguments errors in
api_email_import() for example).