### PR TITLE
Fix: sanitize user values in signup form

### DIFF
--- a/htdocs/signup.html
+++ b/htdocs/signup.html
@@ -41,16 +41,16 @@
 <div class="signup-form">
 <form action="/signup" method="post">
 <input type="hidden" name="force" value="1">
-<input type="hidden" name="username" value="[% username %]">
-<input type="hidden" name="password" value="[% password %]">
+<input type="hidden" name="username" value="[% username | html %]">
+<input type="hidden" name="password" value="[% password | html %]">
 
 <table>
   <tr><td colspan="2" class="section-head">IMAP</td></tr>
   <tr>
     <th>Host</th>
     <td>
-      <input type="text" class="host" name="imapHost" value="[% imapHost %]">
-      <input type="number" class="port" name="imapPort" value="[% imapPort %]">
+      <input type="text" class="host" name="imapHost" value="[% imapHost | html %]">
+      <input type="number" class="port" name="imapPort" value="[% imapPort | html %]">
       <select name="imapSSL">
         <option value="1"[% IF imapSSL == 1 %] selected[% END %]>Plaintext</option>
         <option value="2"[% IF imapSSL == 2 %] selected[% END %]>SSL</option>
@@ -63,8 +63,8 @@
   <tr>
     <th>Host</th>
     <td>
-      <input type="text" class="host" name="smtpHost" value="[% smtpHost %]">
-      <input type="number" class="port" name="smtpPort" value="[% smtpPort %]">
+      <input type="text" class="host" name="smtpHost" value="[% smtpHost | html %]">
+      <input type="number" class="port" name="smtpPort" value="[% smtpPort | html %]">
       <select name="smtpSSL">
         <option value="1"[% IF smtpSSL == 1 %] selected[% END %]>Plaintext</option>
         <option value="2"[% IF smtpSSL == 2 %] selected[% END %]>SSL</option>
@@ -76,11 +76,11 @@
   <tr><td colspan="2" class="section-head">CalDAV / CardDAV (optional)</td></tr>
   <tr>
     <th>CalDAV URL</th>
-    <td><input type="text" class="url" name="caldavURL" value="[% caldavURL %]"></td>
+    <td><input type="text" class="url" name="caldavURL" value="[% caldavURL | html %]"></td>
   </tr>
   <tr>
     <th>CardDAV URL</th>
-    <td><input type="text" class="url" name="carddavURL" value="[% carddavURL %]"></td>
+    <td><input type="text" class="url" name="carddavURL" value="[% carddavURL | html %]"></td>
   </tr>
 </table>
 


### PR DESCRIPTION
I was getting "[Login failed](https://github.com/jmapio/jmap-perl/blob/2c6385bbcafff218d1343d5b130fe472f02563af/bin/jmap-proxy.pl#L420)" messages when trying to sign up.

It turns out that the special characters in my password were not rendered correctly in the signup form.

This PR adds the `| html` filter to all user values in the `signup.html` template.