### PR TITLE
Fall back to LIST when XLIST advertises but returns unusable data

### DIFF
--- a/JMAP/Sync/Common.pm
+++ b/JMAP/Sync/Common.pm
@@ -483,6 +483,14 @@ sub folders {
   my $listcmd = $imap->capability()->{xlist} ? 'xlist' : 'list';
   my @folders = $imap->$listcmd('', '*');
 
+  # Some servers advertise the XLIST capability but don't return
+  # well-formed XLIST data (observed against a Dovecot deployment that
+  # replies to XLIST with just the tagged completion status instead of
+  # folder tuples). Fall back to the standard LIST command in that case.
+  if ($listcmd eq 'xlist' && grep { ref($_) ne 'ARRAY' } @folders) {
+    @folders = $imap->list('', '*');
+  }
+
   my %folders;
   foreach my $folder (@folders) {
     my ($role) = grep { not $KNOWN_SPECIALS{lc $_} } @{$folder->[0]};


### PR DESCRIPTION
## Bug

`JMAP::Sync::Common::folders()` crashes with:

```
Can't use string ("ok") as an ARRAY ref while "strict refs" in use
  at JMAP/Sync/Common.pm line 488
```

on a live Dovecot (poste.io) deployment that advertises the `XLIST`
capability in its `CAPABILITY` response but, when actually sent an
`XLIST` command, replies with just the tagged completion status
instead of well-formed folder tuples.

`folders()` picks the list command based purely on capability
advertisement:

```perl
my $listcmd = $imap->capability()->{xlist} ? 'xlist' : 'list';
my @folders = $imap->$listcmd('', '*');
```

Reproduced directly against the live server with `Mail::IMAPTalk`:

```perl
$imap->list('', '*')   # → 6 well-formed folder tuples, as expected
$imap->xlist('', '*')  # → ('ok')  -- just the completion status
```

Since `@folders` then contains a single non-ref string `'ok'`, the
`foreach` loop's `@{$folder->[0]}` dereference dies with the error
above, aborting account setup entirely (`POST /api/accounts` returns
`201` with a `"setup failed: ..."` warning and the account never
syncs any folders/messages).

## Fix

After calling the capability-selected command, detect a malformed
`XLIST` result (any non-arrayref element) and retry with the standard
`LIST` command, which is universally reliable. This only changes
behavior on the specific failure case — servers with working `XLIST`
are unaffected.

## Testing

Verified end-to-end against the live deployment (poste.io mail server,
Dovecot backend) via the Docker image
(`ghcr.io/jmapio/jmap-proxy:latest`):

- **Before fix:** `POST /api/accounts` → `201` with
  `"warning":"setup failed: Can't use string (\"ok\") as an ARRAY ref..."`,
  account left with 0 folders / 0 messages.
- **After fix:** `POST /api/accounts` → clean `201`, account synced
  `6` folders / `49` messages successfully.

Also confirmed this is not a general "second IMAP command on the
connection" issue — `namespace()` and plain `list()` both work
reliably on this server; only the generic `xlist` dispatch returns
unusable data.